### PR TITLE
#160412462  Hash passwords into datastore on registration, exclude from responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prettier": "^1.14.2"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "debug": "^3.1.0",
     "dotenv": "^6.0.0",
     "express": "^4.16.3",

--- a/src/routes/users/userController.js
+++ b/src/routes/users/userController.js
@@ -80,6 +80,7 @@ const userLogin = (req, res) => {
     if (bcrypt.compare(req.body.password, match.password)) {
       user.details = { ...match };
       user.anonymous = false;
+      delete user.details.password;
 
       res.status(200).json({
         success: true,

--- a/test/test.js
+++ b/test/test.js
@@ -59,7 +59,7 @@ describe('Activity flow:', () => {
   */
 
   describe('register -> login -> order', () => {
-    const newUser = {
+    const userToAdd = {
       username: `martin-Skope`,
       password: `blabla`,
       email: `nyet@pillow.me`
@@ -69,25 +69,30 @@ describe('Activity flow:', () => {
       chai
         .request(server)
         .post(`${ROOT_URL}/users/register`)
-        .send(newUser)
+        .send(userToAdd)
         .end((err, res) => {
           expect(res.status).eq(201);
         });
     });
 
     it('Should save user to datastore', () => {
-      expect(Boolean(users.findByUsername(newUser.username))).eq(true);
+      expect(Boolean(users.findByUsername(userToAdd.username))).eq(true);
+    });
+
+    it('User password should be obfuscated', () => {
+      const userPass = users.findByUsername(userToAdd.username).password;
+      expect(userPass).not.eq(userToAdd.password);
     });
 
     it('Registered user can login', () => {
       chai
         .request(server)
         .post(`${ROOT_URL}/users/login`)
-        .send(newUser)
+        .send(userToAdd)
         .end((err, res) => {
           expect(res.status).eq(200);
           expect(res.body.message).eq(
-            `successful login as ${newUser.username}`
+            `successful login as ${userToAdd.username}`
           );
         });
     });


### PR DESCRIPTION
## What does this PR do?
Fixes #12 
- Hashes user passwords on registration and excludes them from responses

### Description of Task(s) to be completed?
- Hash password into datastore on registration
- Compare client provided password with hash on login
- Exclude password field when returning user instance as response payload

### What are the relevant pivotal tracker stories?
#160412462

### Screenshots (if appropriate)
N/A
